### PR TITLE
fix: prevent lint-staged error on docs-only commits

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -8,8 +8,12 @@ source "$ROOT_DIR/.githooks/config.env"
 cd "$ROOT_DIR" || exit 1
 
 if [ "$ENABLE_CLIENT_HOOKS" == true ]; then
-    cd "$ROOT_DIR/client" || exit 1
-    "${ROOT_DIR}/.githooks/client/pre-commit.sh"
+    CLIENT_STAGED=$(git diff --cached --name-only -- client | head -n 1)
+
+    if [ -n "$CLIENT_STAGED" ]; then
+        cd "$ROOT_DIR/client" || exit 1
+        "${ROOT_DIR}/.githooks/client/pre-commit.sh"
+    fi
 fi
 
 if [ "$ENABLE_SERVER_HOOKS" == true ]; then


### PR DESCRIPTION
pre-commitを更新し、クライアントフックを呼び出す前に、クライアント下のステージングされたファイルを検出するようにした。
これでドキュメントのみのコミットではlint-stagedがトリガーされなくなり、実際のクライアントの変更ではトリガーされるようになるはず。

詳しくはissue #24 みてほしい！

テスト:
README.mdのみをステージングしてpre-commitを実行した場合 (lint-stagedは実行されず、exit 0)
README.mdをステージングしてpre-commitを実行した場合 (lint-stagedは正常に実行されました)

---
Closes #24